### PR TITLE
fix: updage auth referer

### DIFF
--- a/league_client/rso/auth.py
+++ b/league_client/rso/auth.py
@@ -185,7 +185,7 @@ def authorize(
     }
     # referer is very important to prevent cloudflare 403
     headers = HEADERS.copy()
-    headers["referer"] = "https://www.riotgames.com/"
+    headers["referer"] = "https://riotgames.com/"
     res = client.put(
         "https://auth.riotgames.com/api/v1/authorization",
         json=data,


### PR DESCRIPTION
It broke again last night
Solved with changing the referer from `https://www.riotgames.com/` to `https://riotgames.com/`